### PR TITLE
Fix mqtt max brightness

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -355,6 +355,9 @@ void mqttCallback(char* topic, uint8_t* payload, unsigned int length) {
                 case BRIGHTNESS_MID:
                     g_bp->dimmerMid();
                     break;
+                case BRIGHTNESS_MAX:
+                    g_bp->dimmerMax();
+                    break;
                 default:  // MAX values
                     g_bp->on();
                     break;


### PR DESCRIPTION
Before this fix :
Setting brightness to 4 in mqtt (100% in home assistant) just put the device to on, without changing the brightness to Max.

After this fix:
The max brightness is setup correctly on the lamps when putting the light at 100% using home assistant.