### PR TITLE
Fix undefined status that stays forever in home assistant after autoreconnect happens

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,7 +179,7 @@ void loop() {
 #if defined(ESP8266) || defined(ESP32)
     LOG.handle(); // telnetspy handling
     ArduinoOTA.handle();
-    
+
     #if MQTT_ENABLED
     g_mqtt->loop();
 
@@ -210,8 +210,7 @@ void loop() {
             }
         }
     }
-    else
-    {
+    else {
         // Disconnected, force discovery again next time
         g_mqtt->setDiscoveryDone(false);
     }


### PR DESCRIPTION
Retablishes the connexion to homeassistant by republishing autodiscovery data